### PR TITLE
Update readme to specify --with-all-dependencies when composer requiring.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ To use this plugin, you must already have a Drupal project using BLT 11 (or high
 
 1. Add this plugin to your project using composer: 
 
-`composer require --dev mikemadison13/blt-lando`
+`composer require --dev mikemadison13/blt-lando --with-all-dependencies`
 
 Note: if you are using drupal/recommended-project (or another project template) that sets the minimum-stability to "stable" you may have trouble installing this plugin. You can either change your stability to "dev" or more specifically composer require like:
 
-`composer require mikemadison13/blt-lando:dev-main`
+`composer require mikemadison13/blt-lando:dev-main --with-all-dependencies`
 
 2. Ensure that your blt/blt.yml file has properly set the `project.machine_name` key (as this will be used during template generation by this plugin).
 


### PR DESCRIPTION
Using `--with-all-dependencies` is now required when requiring this package.

Using `composer require --dev mikemadison13/blt-lando` alone returns the following:

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires acquia/blt ^13.1 -> satisfiable by acquia/blt[13.1.0].
    - acquia/blt 13.1.0 requires consolidation/robo ^1.4.12 || ^2 -> found consolidation/robo[1.4.12, 1.4.13, 1.5.0, 1.x-dev, 2.0.0-alpha1, ..., 2.x-dev] but the package is fixed to 3.0.6 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```

Using `composer require --dev mikemadison13/blt-lando --with-all-dependencies` resolves the package conflicts.